### PR TITLE
Fix PlayerController Error when user joins

### DIFF
--- a/src/Helpers/DiscordHelper.php
+++ b/src/Helpers/DiscordHelper.php
@@ -148,6 +148,12 @@ class DiscordHelper extends BaseHelper
                 'steam' => $steamId
             ]);
 
+            $insert = $this->db->insert('rankme', [
+                'steam' => $steamId
+            ], [
+
+            ]);
+
             if ($update->execute()) {
                 return !!$this->db->delete('player_link_codes', [
                     'code' => $code

--- a/src/Helpers/DiscordHelper.php
+++ b/src/Helpers/DiscordHelper.php
@@ -149,9 +149,7 @@ class DiscordHelper extends BaseHelper
             ]);
 
             $insert = $this->db->insert('rankme', [
-                'steam' => $steamId
-            ], [
-
+                'steam' => $steamId 
             ]);
 
             if ($update->execute()) {


### PR DESCRIPTION
This fixes the 500 error shown on the bot when a player joins the queue after linking their account. 

`{ status: 500,
  error: 'Argument 1 passed to B3none\\League\\Helpers\\PlayerHelper::isInMatch() must be of the type string, null given, called in /var/www/csgo-league-web/src/Controllers/PlayerController.php on line 47',
  file: '/var/www/csgo-league-web/src/Helpers/PlayerHelper.php',
  line: 77 }`

Once the player is added to the `rankme` table the error goes away.