### PR TITLE
Attempt at automatic redirection when linking account

### DIFF
--- a/src/Controllers/DiscordController.php
+++ b/src/Controllers/DiscordController.php
@@ -33,7 +33,7 @@ class DiscordController extends BaseController
     public function linkDiscord(string $discordId, string $code): string
     {
         if (!$this->steam->loggedIn()) {
-            return "<a href=\"{$this->steam->loginUrl()}\">Login with Steam</a> and visit this URL again.";
+            return "<meta http-equiv=\"Refresh\" content=\"0; url={$this->steam->loginUrl($discordId, $code)}\" />";
         }
 
         $steamId = $this->authorisedUser['steamid'];

--- a/src/Helpers/SteamHelper.php
+++ b/src/Helpers/SteamHelper.php
@@ -109,16 +109,27 @@ class SteamHelper
      *
      * @return string
      */
-    public function loginUrl(): string
+    public function loginUrl($discordId = null, $code = null): string
     {
-        $params = [
-            'openid.ns' => 'http://specs.openid.net/auth/2.0',
-            'openid.mode' => 'checkid_setup',
-            'openid.return_to' => $this->settings['loginpage'],
-            'openid.realm' => $this->settings['loginpage'],
-            'openid.identity' => 'http://specs.openid.net/auth/2.0/identifier_select',
-            'openid.claimed_id' => 'http://specs.openid.net/auth/2.0/identifier_select',
-        ];
+        if ($discordId === null || $code === null) {
+            $params = [
+                'openid.ns' => 'http://specs.openid.net/auth/2.0',
+                'openid.mode' => 'checkid_setup',
+                'openid.return_to' => $this->settings['loginpage'],
+                'openid.realm' => $this->settings['loginpage'],
+                'openid.identity' => 'http://specs.openid.net/auth/2.0/identifier_select',
+                'openid.claimed_id' => 'http://specs.openid.net/auth/2.0/identifier_select',
+            ];
+        } else {
+            $params = [
+                'openid.ns' => 'http://specs.openid.net/auth/2.0',
+                'openid.mode' => 'checkid_setup',
+                'openid.return_to' => 'http://pugs.viquity.pro/{$discordId}/{$code}',  # FIXME: Get host dynamically
+                'openid.realm' => $this->settings['loginpage'],
+                'openid.identity' => 'http://specs.openid.net/auth/2.0/identifier_select',
+                'openid.claimed_id' => 'http://specs.openid.net/auth/2.0/identifier_select',
+            ];
+        }
 
         return 'https://steamcommunity.com/openid/login?' . http_build_query($params, '', '&');
     }

--- a/src/Helpers/SteamHelper.php
+++ b/src/Helpers/SteamHelper.php
@@ -111,25 +111,17 @@ class SteamHelper
      */
     public function loginUrl($discordId = null, $code = null): string
     {
-        if ($discordId === null || $code === null) {
-            $params = [
-                'openid.ns' => 'http://specs.openid.net/auth/2.0',
-                'openid.mode' => 'checkid_setup',
-                'openid.return_to' => $this->settings['loginpage'],
-                'openid.realm' => $this->settings['loginpage'],
-                'openid.identity' => 'http://specs.openid.net/auth/2.0/identifier_select',
-                'openid.claimed_id' => 'http://specs.openid.net/auth/2.0/identifier_select',
-            ];
-        } else {
-            $params = [
-                'openid.ns' => 'http://specs.openid.net/auth/2.0',
-                'openid.mode' => 'checkid_setup',
-                'openid.return_to' => 'http://pugs.viquity.pro/{$discordId}/{$code}',  # FIXME: Get host dynamically
-                'openid.realm' => $this->settings['loginpage'],
-                'openid.identity' => 'http://specs.openid.net/auth/2.0/identifier_select',
-                'openid.claimed_id' => 'http://specs.openid.net/auth/2.0/identifier_select',
-            ];
-        }
+        
+        $returnTo = ($discordId === null || $code === null) ? $this->settings['loginpage'] : env('URL') . "/{$discordId}/{$code}";
+        
+        $params = [
+            'openid.ns' => 'http://specs.openid.net/auth/2.0',
+            'openid.mode' => 'checkid_setup',
+            'openid.return_to' => $returnTo,
+            'openid.realm' => $this->settings['loginpage'],
+            'openid.identity' => 'http://specs.openid.net/auth/2.0/identifier_select',
+            'openid.claimed_id' => 'http://specs.openid.net/auth/2.0/identifier_select',
+        ];
 
         return 'https://steamcommunity.com/openid/login?' . http_build_query($params, '', '&');
     }


### PR DESCRIPTION
Added some spaghetti code showing how we could automatically redirect users when they are linking their account. This makes it so they don't have to click the Steam OpenID link themselves, and also don't have to revisit the link after signing into Steam. Not sure if this works at all, but I'd hope we can clean it up in this pull request if it's something we want.