### PR TITLE
fix cors error

### DIFF
--- a/assets/scripts/listeners/steam-profile.js
+++ b/assets/scripts/listeners/steam-profile.js
@@ -11,7 +11,7 @@ export function listen() {
 }
 
 const updateSteamProfile = (element, steam) => {
-  axios.get(`https://cors-anywhere.herokuapp.com/https://steamcommunity.com/profiles/${steam}?xml=true`)
+  axios.get(`https://secret-ocean-49799.herokuapp.com/https://steamcommunity.com/profiles/${steam}?xml=true`)
     .then(response => {
       let profileXML;
 


### PR DESCRIPTION
the cors-anywhere link returns a 403 so steam profile information doesn't load. using another proxy fixes this issue.