### PR TITLE
add default score on first link

### DIFF
--- a/src/Helpers/DiscordHelper.php
+++ b/src/Helpers/DiscordHelper.php
@@ -174,6 +174,7 @@ class DiscordHelper extends BaseHelper
         if (!$this->isInRankme($steamId)) {
             $this->db->insert('rankme', [
                 'steam' => $steamId,
+                'score' => 1000,
             ]);
         }
 


### PR DESCRIPTION
Team balancing based on rankme points becomes broken when new players link for the first time because their score is set to `NULL` until they connect to the game server. This gives them the starting value of `1000`.